### PR TITLE
Update Todoist OAuth scope to read-only

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -27,7 +27,7 @@ export const authOptions: NextAuthOptions = {
       authorization: {
         url: "https://todoist.com/oauth/authorize",
         params: {
-          scope: "data:read_write",
+          scope: "data:read",
           response_type: "code",
           redirect_uri: `${process.env.NEXTAUTH_URL}/api/auth/callback/todoist`,
         },


### PR DESCRIPTION
This PR updates the Todoist OAuth scope from `data:read_write` to `data:read` to ensure the app only requests read permissions. This addresses user feedback and aligns with the app's functionality, as write access is not required.