### PR TITLE
feat: Add project filtering to Dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todoist-dashboard",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": false,
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Implements project filtering functionality in the Dashboard, allowing users to filter all metrics and visualizations by specific projects. Uses same component as recurring tasks page.

Version bump: 0.5.1 -> 0.6.0