### PR TITLE
fix: update overdue task calculation to use local date comparison

### DIFF
--- a/utils/calculateBacklogHealth.ts
+++ b/utils/calculateBacklogHealth.ts
@@ -94,11 +94,13 @@ export function calculateBacklogHealth(
       : (sortedAges[Math.floor(sortedAges.length / 2)] ?? 0)
     : 0;
 
-  // Count problematic tasks
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0);
+
   const overdueCount = nonRecurringTasks.filter(task => {
     if (!task.due?.date) return false;
-    const dueDate = new Date(task.due.date);
-    return dueDate < now;
+    const [y, m, d] = task.due.date.split('-').map(Number);
+    const dueLocal = new Date(y!, m! - 1, d!);
+    return dueLocal < todayStart;
   }).length;
 
   const staleCount = taskAges.filter(age => age >= 30).length;
@@ -160,8 +162,12 @@ export function calculateBacklogHealth(
     }
 
     const age = differenceInDays(now, createdAt);
-    const dueDate = task.due?.date ? new Date(task.due.date) : null;
-    const isOverdue = dueDate && dueDate < now;
+    let dueLocal: Date | null = null;
+    if (task.due?.date) {
+      const [y, m, d] = task.due.date.split('-').map(Number);
+      dueLocal = new Date(y!, m! - 1, d!);
+    }
+    const isOverdue = dueLocal && dueLocal < todayStart;
 
     // Determine if task needs review (priority order: overdue > very stale > old unscheduled > high priority unscheduled)
     let shouldReview = false;


### PR DESCRIPTION
## Summary

* What does this PR do?
Fixes overdue task calculation to use local date comparison.
* Why is this change needed?
Previously tasks that I just created today were showing up as overdue:
<img width="623" height="741" alt="image" src="https://github.com/user-attachments/assets/37c3bfdb-b30a-4cb2-a917-bc8737a5245d" />


## Changes

* Added local date handling for overdue tasks

## Testing

* How did you test this?
In Chrome
* Any steps for reviewers to verify?
See before and after for this component.

## Notes

* Any context, tradeoffs, or follow-up work?
This PR assumes it was not intentional to show tasks created today as overdue.
* Any related issues or discussions?
n/a

## Checklist

* [x] I tested my changes
* [x] I updated documentation if needed
* [x] I kept the change scoped and relevant