### PR TITLE
v0.13.1 - Consolidate echarts typings, drop dead dependencies

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,16 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "no-restricted-imports": [
+      "error",
+      {
+        "patterns": [
+          {
+            "group": ["echarts/types/*", "echarts/types/**"],
+            "message": "Import echarts types from the public 'echarts' entry point instead. echarts/types/dist/* is internal and has no stability guarantee. Shared aliases live in types/echarts.ts."
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/components/ActiveTasksByProject.tsx
+++ b/components/ActiveTasksByProject.tsx
@@ -1,20 +1,11 @@
 import ReactECharts from 'echarts-for-react';
 import { colorNameToHex } from "@/utils/projectUtils";
 import escapeHtml from '@/utils/escapeHtml';
-import * as echarts from 'echarts/core';
-import {
-  TooltipComponentOption,
-  GridComponentOption
-} from 'echarts/components';
-import { BarSeriesOption } from 'echarts/charts';
-import { CallbackDataParams } from 'echarts/types/dist/shared';
+import type { EChartsOption } from 'echarts';
+import type { CallbackDataParams } from '../types/echarts';
 import { TodoistColor } from '../types';
 import Spinner from './shared/Spinner';
 import { CHART_TOOLTIP, AXIS_LABEL, AXIS_LINE, SPLIT_LINE } from '../utils/chartTheme';
-
-type ECOption = echarts.ComposeOption<
-  TooltipComponentOption | GridComponentOption | BarSeriesOption
->;
 
 interface Project {
   id: string;
@@ -55,7 +46,7 @@ export default function ActiveTasksByProject({ projectData, activeTasks, loading
     };
   });
 
-  const option: ECOption = {
+  const option: EChartsOption = {
     tooltip: {
       trigger: 'axis',
       ...CHART_TOOLTIP,

--- a/components/CompletedByTimeOfDay.tsx
+++ b/components/CompletedByTimeOfDay.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import ReactECharts from 'echarts-for-react';
 import { format } from 'date-fns';
-import { EChartsOption } from 'echarts';
-import { CallbackDataParams } from 'echarts/types/dist/shared';
+import type { EChartsOption } from 'echarts';
+import type { CallbackDataParams } from '../types/echarts';
 import { CompletedTask } from '../types';
 import escapeHtml from '@/utils/escapeHtml';
 import Spinner from './shared/Spinner';

--- a/components/CompletedTasksByProject.tsx
+++ b/components/CompletedTasksByProject.tsx
@@ -1,21 +1,12 @@
 import React from 'react';
 import ReactECharts from 'echarts-for-react';
 import { colorNameToHex } from "@/utils/projectUtils";
-import * as echarts from 'echarts/core';
-import {
-  TooltipComponentOption,
-  GridComponentOption
-} from 'echarts/components';
-import { BarSeriesOption } from 'echarts/charts';
-import { CallbackDataParams } from 'echarts/types/dist/shared';
+import type { EChartsOption } from 'echarts';
+import type { CallbackDataParams } from '../types/echarts';
 import { ProjectData, TodoistColor } from '../types';
 import escapeHtml from '@/utils/escapeHtml';
 import Spinner from './shared/Spinner';
 import { CHART_TOOLTIP, AXIS_LABEL, AXIS_LINE, SPLIT_LINE } from '../utils/chartTheme';
-
-type ECOption = echarts.ComposeOption<
-  TooltipComponentOption | GridComponentOption | BarSeriesOption
->;
 
 interface ProjectWithStats extends ProjectData {
   completedTasksCount: number;
@@ -35,7 +26,7 @@ function CompletedTasksByProject({ projectData, loading }: CompletedTasksByProje
     );
   }
 
-  const option: ECOption = {
+  const option: EChartsOption = {
     tooltip: {
       trigger: 'axis',
       ...CHART_TOOLTIP,

--- a/components/CompletedTasksOverTime.tsx
+++ b/components/CompletedTasksOverTime.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import ReactECharts from 'echarts-for-react';
 import * as echarts from 'echarts/core';
-import { CallbackDataParams } from 'echarts/types/dist/shared';
-import { EChartsOption } from 'echarts';
+import type { EChartsOption } from 'echarts';
+import type { CallbackDataParams } from '../types/echarts';
 import {
   format,
   endOfWeek,

--- a/components/CompletionHeatmap.tsx
+++ b/components/CompletionHeatmap.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactECharts from 'echarts-for-react';
-import { EChartsOption } from 'echarts';
+import type { EChartsOption } from 'echarts';
 import { CompletedTask } from '../types';
 import { calculateCompletionHeatmapData } from '../utils/calculateCompletionHeatmapData';
 import Spinner from './shared/Spinner';

--- a/components/LabelDistribution.tsx
+++ b/components/LabelDistribution.tsx
@@ -1,13 +1,8 @@
 import React, { useMemo } from 'react';
 import ReactECharts from 'echarts-for-react';
 import { colorNameToHex } from '@/utils/projectUtils';
-import * as echarts from 'echarts/core';
-import {
-  TooltipComponentOption,
-  GridComponentOption
-} from 'echarts/components';
-import { BarSeriesOption } from 'echarts/charts';
-import { CallbackDataParams } from 'echarts/types/dist/shared';
+import type { EChartsOption } from 'echarts';
+import type { CallbackDataParams } from '../types/echarts';
 import type { Label, ActiveTask, CompletedTask } from '../types';
 import { getLabelStats } from '@/utils/parseLabelsFromContent';
 import escapeHtml from '@/utils/escapeHtml';
@@ -18,10 +13,6 @@ import {
   CHART_TOOLTIP,
   AXIS_LINE,
 } from '../utils/chartTheme';
-
-type ECOption = echarts.ComposeOption<
-  TooltipComponentOption | GridComponentOption | BarSeriesOption
->;
 
 export type LabelViewMode = 'all' | 'active';
 
@@ -75,7 +66,7 @@ function LabelDistribution({ activeTasks, completedTasks, labels, loading, viewM
     );
   }
 
-  const option: ECOption = {
+  const option: EChartsOption = {
     tooltip: {
       trigger: 'axis',
       axisPointer: {

--- a/components/ProjectVelocity.tsx
+++ b/components/ProjectVelocity.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import ReactECharts from 'echarts-for-react';
-import { EChartsOption, BarSeriesOption } from 'echarts';
+import type { EChartsOption, BarSeriesOption } from 'echarts';
 import { format } from 'date-fns';
 import { CompletedTask, ProjectData, TodoistColor } from '../types';
 import { calculateProjectVelocity, VelocityData } from '../utils/calculateProjectVelocity';

--- a/components/TaskLeadTime.tsx
+++ b/components/TaskLeadTime.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactECharts from 'echarts-for-react';
-import { EChartsOption } from 'echarts';
+import type { EChartsOption } from 'echarts';
 import { CompletedTask, ActiveTask } from '../types';
 import { calculateLeadTimeStats, LeadTimeStats } from '../utils/calculateLeadTimeStats';
 import Spinner from './shared/Spinner';

--- a/components/TaskPriority.tsx
+++ b/components/TaskPriority.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactECharts from 'echarts-for-react';
-import { EChartsOption } from 'echarts';
+import type { EChartsOption } from 'echarts';
 import { ActiveTask } from '../types';
 import Spinner from './shared/Spinner';
 import { CHART_TOOLTIP, WARM_GRAY, WARM_BLUE, WARM_PEACH, WARM_PEACH_DARK, WARM_BLACK, TEXT_PRIMARY } from '../utils/chartTheme';

--- a/components/TrendChart.tsx
+++ b/components/TrendChart.tsx
@@ -2,13 +2,13 @@ import { useEffect, useRef } from 'react';
 import * as echarts from 'echarts/core';
 import {
   TooltipComponent,
-  TooltipComponentOption,
+  type TooltipComponentOption,
   GridComponent,
-  GridComponentOption
+  type GridComponentOption
 } from 'echarts/components';
-import { LineChart, LineSeriesOption } from 'echarts/charts';
+import { LineChart, type LineSeriesOption } from 'echarts/charts';
 import { CanvasRenderer } from 'echarts/renderers';
-import { CallbackDataParams } from 'echarts/types/dist/shared';
+import type { CallbackDataParams } from '../types/echarts';
 import {
   WARM_BLUE,
   WARM_GRAY,

--- a/components/shared/VersionInfo.tsx
+++ b/components/shared/VersionInfo.tsx
@@ -2,10 +2,17 @@ import React, { useState } from 'react';
 import { FaTimes } from 'react-icons/fa';
 
 // Current version number
-const APP_VERSION = '0.13.0';
+const APP_VERSION = '0.13.1';
 
 // Changelog entries - newest first
 const CHANGELOG = [
+  {
+    version: '0.13.1',
+    date: 'July 2026',
+    changes: [
+      'Internal: consolidated ECharts typings and removed three unused dependencies',
+    ]
+  },
   {
     version: '0.13.0',
     date: 'July 2026',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,21 @@
 {
   "name": "todoist-dashboard",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "todoist-dashboard",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT",
       "dependencies": {
         "@doist/todoist-api-typescript": "^6.5.0",
         "@next-auth/prisma-adapter": "^1.0.7",
         "@types/d3": "^7.4.3",
         "@types/d3-cloud": "^1.2.9",
-        "@types/d3-scale-chromatic": "^3.1.0",
-        "@types/echarts": "^4.9.22",
         "@types/react-sparklines": "^1.7.5",
         "d3": "^7.9.0",
         "d3-cloud": "^1.2.7",
-        "d3-scale-chromatic": "^3.1.0",
         "date-fns": "^4.1.0",
         "dotenv": "^16.3.1",
         "echarts": "^5.5.1",
@@ -1475,15 +1472,6 @@
         "@types/ms": "*"
       }
     },
-    "node_modules/@types/echarts": {
-      "version": "4.9.22",
-      "resolved": "https://registry.npmjs.org/@types/echarts/-/echarts-4.9.22.tgz",
-      "integrity": "sha512-7Fo6XdWpoi8jxkwP7BARUOM7riq8bMhmsCtSG8gzUcJmFhLo387tihoBYS/y5j7jl3PENT5RxeWZdN9RiwO7HQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/zrender": "*"
-      }
-    },
     "node_modules/@types/geojson": {
       "version": "7946.0.14",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
@@ -1566,12 +1554,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
-    },
-    "node_modules/@types/zrender": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@types/zrender/-/zrender-4.0.6.tgz",
-      "integrity": "sha512-1jZ9bJn2BsfmYFPBHtl5o3uV+ILejAtGrDcYSpT4qaVKEI/0YY+arw3XHU04Ebd8Nca3SQ7uNcLaqiL+tTFVMg==",
-      "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todoist-dashboard",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": false,
   "license": "MIT",
   "repository": {
@@ -18,12 +18,9 @@
     "@next-auth/prisma-adapter": "^1.0.7",
     "@types/d3": "^7.4.3",
     "@types/d3-cloud": "^1.2.9",
-    "@types/d3-scale-chromatic": "^3.1.0",
-    "@types/echarts": "^4.9.22",
     "@types/react-sparklines": "^1.7.5",
     "d3": "^7.9.0",
     "d3-cloud": "^1.2.7",
-    "d3-scale-chromatic": "^3.1.0",
     "date-fns": "^4.1.0",
     "dotenv": "^16.3.1",
     "echarts": "^5.5.1",

--- a/types/echarts.ts
+++ b/types/echarts.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared echarts type aliases.
+ *
+ * echarts exports its tooltip/label callback params type publicly only under the name
+ * `DefaultLabelFormatterCallbackParams`. The short `CallbackDataParams` name is also
+ * reachable from `echarts/types/dist/shared`, but that is an internal path with no
+ * stability guarantee, so we alias the public export here instead and import this
+ * module from chart components.
+ */
+export type { DefaultLabelFormatterCallbackParams as CallbackDataParams } from 'echarts';


### PR DESCRIPTION
**v0.13.1** — patch. Internal refactor, no behaviour change.

Cleans up the echarts typing mess that broke `tsc` mid-way through v0.13.0.

- **Remove `@types/echarts@4`** — v4 types for a v5 runtime. Nothing imported it, but it was auto-included as an ambient type-reference directive, with `skipLibCheck` hiding the conflict.
- **Move 6 components off `echarts/types/dist/shared`** (internal path, no stability guarantee) onto the public entry. That type is only exported as `DefaultLabelFormatterCallbackParams`, so `types/echarts.ts` aliases it back to `CallbackDataParams` in one place.
- **Add an eslint rule** blocking `echarts/types/**` so the internal path can't come back.
- **Mark type-only echarts imports `import type`.** Three `ReactECharts` components had no runtime echarts usage at all, so they now use `EChartsOption` like the other four. `TrendChart` keeps `ComposeOption` — it actually tree-shakes via `use()`.
- **Remove `d3-scale-chromatic` + its types** — zero references; `d3.schemeSet3` still resolves via the `d3` umbrella.

Bundle output is byte-identical, so this is maintainability only, not a size win.

`tsc` 0 · lint clean · build ✓ · routes 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
