### PR TITLE
v0.14.0 - Upgrade ECharts to 6.1.0 (XSS patch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,12 +155,11 @@ Note that `sharp 0.35` requires Node.js >= 20.9, which sets the project's Node f
 
 ### Accepted `npm audit` findings
 
-Two advisories are knowingly left unresolved. Both are inapplicable to this project, and both would cost more than they buy:
+One advisory is knowingly left unresolved:
 
 - **`brace-expansion` ([GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), high)** — reached only through the ESLint and Tailwind build toolchains, so it is never shipped to users. The advisory is patched only in `brace-expansion@5.0.8`, whose CommonJS entry point exports an object rather than a callable, so forcing it makes `minimatch@3.x` throw `TypeError: expand is not a function`. `npm audit`'s suggested alternative is `eslint@4.0.0`, a four-major downgrade. Revisit when ESLint's dependency tree reaches a patched `brace-expansion` on its own.
-- **`echarts` ([GHSA-fgmj-fm8m-jvvx](https://github.com/advisories/GHSA-fgmj-fm8m-jvvx), moderate XSS)** — the vulnerable path is the *built-in* tooltip formatter of the `lines` series. This project uses no `lines` series (only `bar`, `line`, `pie` and `heatmap`), and every chart supplies its own `formatter`, so neither precondition holds. The fix requires `echarts@6`, which changes the default theme and legend placement and would visibly regress the dashboard's design for no security gain.
 
-Because `npm audit` counts every dependent of a vulnerable package separately, the ESLint chain alone accounts for most of the reported total. The distinct advisory count is two.
+Because `npm audit` counts every dependent of a vulnerable package separately, this single advisory accounts for the entire reported total.
 
 ## Disclaimer
 

--- a/components/ProjectVelocity.tsx
+++ b/components/ProjectVelocity.tsx
@@ -147,6 +147,10 @@ function ProjectVelocity({
     },
     legend: {
       data: limitedProjectIds.map(id => projectNames[id] || 'Unknown'),
+      // Pinned explicitly: ECharts 6 moved the default legend position to the bottom
+      // of the canvas. This keeps the legend above the chart as designed.
+      top: 0,
+      left: 'center',
       textStyle: {
         color: WARM_GRAY
       },

--- a/components/shared/VersionInfo.tsx
+++ b/components/shared/VersionInfo.tsx
@@ -2,10 +2,17 @@ import React, { useState } from 'react';
 import { FaTimes } from 'react-icons/fa';
 
 // Current version number
-const APP_VERSION = '0.13.1';
+const APP_VERSION = '0.14.0';
 
 // Changelog entries - newest first
 const CHANGELOG = [
+  {
+    version: '0.14.0',
+    date: 'July 2026',
+    changes: [
+      'Security: upgraded ECharts to v6.1.0, patching an XSS vulnerability (CVE-2026-45249)',
+    ]
+  },
   {
     version: '0.13.1',
     date: 'July 2026',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "todoist-dashboard",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "todoist-dashboard",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@doist/todoist-api-typescript": "^6.5.0",
@@ -18,7 +18,7 @@
         "d3-cloud": "^1.2.7",
         "date-fns": "^4.1.0",
         "dotenv": "^16.3.1",
-        "echarts": "^5.5.1",
+        "echarts": "^6.1.0",
         "echarts-for-react": "^3.0.2",
         "framer-motion": "^11.13.1",
         "isomorphic-unfetch": "^4.0.2",
@@ -3048,13 +3048,13 @@
       "license": "MIT"
     },
     "node_modules/echarts": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
-      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
+      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.6.1"
+        "zrender": "6.1.0"
       }
     },
     "node_modules/echarts-for-react": {
@@ -9072,9 +9072,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
-      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
+      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tslib": "2.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todoist-dashboard",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "private": false,
   "license": "MIT",
   "repository": {
@@ -23,7 +23,7 @@
     "d3-cloud": "^1.2.7",
     "date-fns": "^4.1.0",
     "dotenv": "^16.3.1",
-    "echarts": "^5.5.1",
+    "echarts": "^6.1.0",
     "echarts-for-react": "^3.0.2",
     "framer-motion": "^11.13.1",
     "isomorphic-unfetch": "^4.0.2",


### PR DESCRIPTION
**v0.14.0** — minor. Patches the last non-devDependency advisory.

Resolves [GHSA-fgmj-fm8m-jvvx](https://github.com/advisories/GHSA-fgmj-fm8m-jvvx) / CVE-2026-45249 (moderate XSS), fixed only in echarts 6.1.0.

- **Upgrade echarts 5.6.0 → 6.1.0.** No typing changes needed — `tsc` passes as-is.
- **Pin `ProjectVelocity`'s legend to top/center.** It's the only chart with a legend and never set a position, so echarts 6's new bottom-of-canvas default would have moved it.
- **README:** `brace-expansion` (devDependency-only) is now the sole accepted advisory.

`npm audit` goes from 20 findings to 19 — all one advisory, the ESLint/Tailwind `brace-expansion` chain that never ships.

**Cost:** the bundle grows. Dashboard route 154 → 163 kB, first load 459 → 475 kB, shared 232 → 239 kB.

Minor rather than patch because a charting-library major can shift visuals.

`tsc` 0 · lint clean · build ✓ · routes 200 · charts visually checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
